### PR TITLE
Fix error reading empty json file

### DIFF
--- a/components/convert-component.ts
+++ b/components/convert-component.ts
@@ -91,6 +91,7 @@ export class ConvertComponent extends ConverterComponent {
          * Create main file which would contains all global functions.
          */
         this.fileOperations.createFile(this.mainDirToExport, null, Constants.GLOBAL_FUNCS_FILE_NAME, 'json');
+        this.fileOperations.appendFileData(this.mainDirToExport, null, Constants.GLOBAL_FUNCS_FILE_NAME, 'json', {});
     }
 
     private onResolveEnd(...rest) {


### PR DESCRIPTION
JSON data may not be output to `globalFunctions.json`. [link](https://github.com/IgniteUI/typedoc-plugin-localization/blob/1.2.1/components/convert-component.ts#L113-L115)
In that case, formatting error occurs when reading the file.  [link](https://github.com/IgniteUI/typedoc-plugin-localization/blob/1.2.1/utils/file-operations.ts#L129)

Therefore, we modified to output empty JSON data when generating `globalFunctions.json`.
