### PR TITLE
Add a new config option we could use in case a single product (like w…

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -27,6 +27,7 @@ export class Constants {
     static readonly TEMPLATE_STRINGS_OPTION = 'templateStrings';
     static readonly INCLUDE_VERSIONS_OPTION = 'versioning';
     static readonly PRODUCT_OPTION = 'product';
+    static readonly CONFIG_OPTION = 'config';
 
     static readonly GLOBAL_FUNCS_FILE_NAME = 'globalFunctions';
 }

--- a/utils/options.ts
+++ b/utils/options.ts
@@ -55,4 +55,9 @@ export function pluginOptions(options: Pick<Options, "addDeclaration">) {
         name: Constants.PRODUCT_OPTION,
         help: 'Specify product name.'
     });
+
+        options.addDeclaration({
+        name: Constants.CONFIG_OPTION,
+        help: 'Specify config json file name to use for url configurations.'
+    });
 }


### PR DESCRIPTION
…ebcomponents) has api docs deployed in multiple different endpoints so each needs unique config.

Related to https://github.com/IgniteUI/igniteui-webcomponents/issues/991#issuecomment-1831754915
More info can be read in that issue.

In short: WebComponents deploy their api docs in 3 completely different places and we'll need a separate config (similar to the [angular](https://github.com/IgniteUI/ig-typedoc-theme/blob/master/config.json) one) but for each one.
